### PR TITLE
Populate an OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - jhrozek
+reviewers:
+  - jaormx
+  - jhrozek
+  - mrogers950


### PR DESCRIPTION
Hi, I'm from a team maintaining OpenShift Prow instance which is
configured to perform some actions on this repo. Some of the actions
need OWNERS file, so I'm submitting one with names of the people who
seem to be active in PRs to this repo.

For this repo OWNERS only determines who gets automatically asked for
reviews (the blunderbuss plugin), it does not give any rights for
approvals or merges.