### PR TITLE
Make calls to kubernetes more resilient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
 GO=GO111MODULE=on go
 PKGS=github.com/openshift/scapresults/cmd/scapresults
+APP_NAME=scapresults
+NAMESPACE?=openshift-compliance
+
+# Container image variables
+# =========================
+IMAGE_REPO?=quay.io/jhrozek
+IMAGE_TAG?=latest
+# Image path to use. Set this if you want to use a specific path for building
+# or your e2e tests. This is overwritten if we bulid the image and push it to
+# the cluster or if we're on CI.
+IMAGE_PATH?=$(IMAGE_REPO)/$(APP_NAME)
+RUNTIME?=podman
 
 all: build
 
@@ -28,4 +40,57 @@ build: fmt verify
 
 .PHONY: image
 image:
-	podman build -f Dockerfile -t scapresults:latest
+	podman build -f Dockerfile -t $(IMAGE_PATH):$(IMAGE_TAG)
+
+
+# This checks if we're in a CI environment by checking the IMAGE_FORMAT
+# environmnet variable. if we are, lets ues the image from CI and use this
+# operator as the component.
+#
+# The IMAGE_FORMAT variable comes from CI. It is of the format:
+#     <image path in CI registry>:${component}
+# Here define the `component` variable, so, when we overwrite the
+# IMAGE_PATH variable, it'll expand to the component we need.
+.PHONY: check-if-ci
+check-if-ci:
+ifdef IMAGE_FORMAT
+	@echo "IMAGE_FORMAT variable detected. We're in a CI enviornment."
+	$(eval component = $(APP_NAME))
+	$(eval IMAGE_PATH = $(IMAGE_FORMAT))
+else
+	@echo "IMAGE_FORMAT variable missing. We're in local enviornment."
+endif
+
+# If IMAGE_FORMAT is not defined, it means that we're not running on CI, so we
+# probably want to push the compliance-operator image to the cluster we're
+# developing on. This target exposes temporarily the image registry, pushes the
+# image, and remove the route in the end.
+.PHONY: image-to-cluster
+ifdef IMAGE_FORMAT
+image-to-cluster:
+	@echo "We're in a CI environment, skipping image-to-cluster target."
+else
+image-to-cluster: namespace openshift-user image
+	@echo "Temporarily exposing the default route to the image registry"
+	@oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+	@echo "Pushing image $(IMAGE_PATH):$(IMAGE_TAG) to the image registry"
+	IMAGE_REGISTRY_HOST=$$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}'); \
+		$(RUNTIME) login --tls-verify=false -u $(OPENSHIFT_USER) -p $(shell oc whoami -t) $${IMAGE_REGISTRY_HOST}; \
+		$(RUNTIME) push --tls-verify=false $(IMAGE_PATH):$(IMAGE_TAG) $${IMAGE_REGISTRY_HOST}/$(NAMESPACE)/$(APP_NAME):$(IMAGE_TAG)
+	@echo "Removing the route from the image registry"
+	@oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":false}}' --type=merge
+	$(eval IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(APP_NAME):$(TAG))
+endif
+
+.PHONY: namespace
+namespace:
+	@echo "Creating '$(NAMESPACE)' namespace/project"
+	@oc create namespace $(NAMESPACE) || true
+
+.PHONY: openshift-user
+openshift-user:
+ifeq ($(shell oc whoami 2> /dev/null),kube:admin)
+	$(eval OPENSHIFT_USER = kubeadmin)
+else
+	$(eval OPENSHIFT_USER = $(oc whoami))
+endif

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/scapresults
 go 1.13
 
 require (
+	github.com/cenkalti/backoff/v3 v3.1.1
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/hashicorp/consul/api v1.3.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,9 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff/v3 v3.1.1 h1:UBHElAnr3ODEbpqPzX8g5sBcASjoLFtt3L/xwJ01L6E=
+github.com/cenkalti/backoff/v3 v3.1.1/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=


### PR DESCRIPTION
In case there are issues with the deployment, we retry (with backoff).

This also adds the necessary bits in the Makefile to push this image to
the cluster to be able to easily test this.